### PR TITLE
fixed path to exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bem vindo ao curso de Teoria de Resposta ao Item com R do [Progama de Mestrado e
 
 -   Slides: <http://www.labape.com.br/rprimi/TRI/a3_rasch.pdf>
 
-    -   Exercício 3: Calibração Rasch: [Ex3_Rasch.rmd](https://github.com/rprimi/tri/blob/main/aulas_exercicios/Ex3_Rasch.rmd)
+    -   Exercício 3: Calibração Rasch: [Ex3_Rasch.rmd](https://github.com/rprimi/tri/blob/main/aulas_exercicios/Ex3_Rasch.Rmd)
 
     -   Dados gf_matrix [gf_matrix.xlsx](http://www.labape.com.br/rprimi/TRI/2017_exercicios/gf_matrix.xlsx)
 


### PR DESCRIPTION
ótimo material. O caminho para o documento [Ex3_Rasch.rmd](https://github.com/rprimi/tri/blob/main/aulas_exercicios/Ex3_Rasch.rmd) esta com o .rmd, tudo minúsculo, aí estava dando erro. Quando coloca .Rmd (R maiúsculo) aí vai pro lugar certo: [Ex3_Rasch.Rmd](https://github.com/rprimi/tri/blob/main/aulas_exercicios/Ex3_Rasch.Rmd) Sugiro tb colocar o nome do documento com final .Rmd ao invés de .rmd, que aí fica padrao. 